### PR TITLE
IDs for the Ping Host form were incorrect. Referencing #5

### DIFF
--- a/wordcrash-functionality.php
+++ b/wordcrash-functionality.php
@@ -13,7 +13,7 @@ License: GPL2
  * Convert the hidden field's value from ID to email address
  * First number in filter name is form ID, second is field ID
  */
-add_filter( 'gform_get_input_value_2_4', 'wc_host_id_to_email', 10 );
+add_filter( 'gform_get_input_value_3_1', 'wc_host_id_to_email', 10 );
 function wc_host_id_to_email( $value ) {
 	$email = get_userdata( $value );
 	$email = $email->user_email;


### PR DESCRIPTION
Somehow these got messed up. Perhaps when the site was made into a standalone install.

It is possible this could have been causing the problem in #5. `Form ID 2, Field ID 4` would have been a Name Field, which would cause `get_userdata()` to not only fail, but run on the wrong Form. This potentially could have broken the Form Submission process for the Host Form.
